### PR TITLE
fix: Fix iOS 10 AVPlayerItem dealloc crash.

### DIFF
--- a/Sources/TrailerPlayer/Player/TrailerPlayer.swift
+++ b/Sources/TrailerPlayer/Player/TrailerPlayer.swift
@@ -70,6 +70,13 @@ public extension TrailerPlayer {
     }
     
     func toggleMute() { isMuted = !isMuted }
+    
+    override func replaceCurrentItem(with item: AVPlayerItem?) {
+        if currentItem != nil {
+            reset()
+        }
+        super.replaceCurrentItem(with: item)
+    }
 }
 
 private extension TrailerPlayer {


### PR DESCRIPTION
Fix crash in iOS 10 with error message:
``` 
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x1700146c0 of class AVPlayerItem was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x170038540> (
<NSKeyValueObservance 0x174852f00: Observer: 0x1708454c0, Key path: status, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x170857100>
)'
*** First throw call stack:
(0x185036fe0 0x183a98538 0x185036f28 0x185a93160 0x18ca03e20 0x183f43a68 0x105ddda10 0x105de2b78 0x184fe50c8 0x184fe2ce4 0x184f12da4 0x18697d074 0x18b1cdc9c 0x1001034dc 0x183f2159c)
libc++abi.dylib: terminating with uncaught exception of type NSException```